### PR TITLE
fix(test-semver-2): jk

### DIFF
--- a/release/lib/index.ts
+++ b/release/lib/index.ts
@@ -40,6 +40,7 @@ const createNpmrc = async (dir: string): Promise<void> => await writeFile(join(d
         '--ci',
         gitChangelog,
         `--git.tagName "${name}-v\\\${version}"`,
+        '--git.tag true',
         `--git.commitMessage Chore: release ${name} v\\\${version}`,
         '--github.release true'
       ], { cwd })
@@ -60,6 +61,7 @@ const createNpmrc = async (dir: string): Promise<void> => await writeFile(join(d
         '--no-increment',
         `--git.tagName "${name}-v\\\${version}"`,
         '--github.release true',
+        '--git.tag true',
         gitChangelog
       ], { cwd })
       command.stdout?.pipe(process.stdout)


### PR DESCRIPTION
Actually fixes release ci by addind `--git.tag true` as a CLI arg.